### PR TITLE
(fix) #444 add port mapping to dev service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - ./legacy/logs/:/usr/src/clist/logs/legacy/
       - ./logs/postgres/:/usr/src/clist/logs/postgres/
       - ./legacy/api/:/usr/src/clist/legacy/api/
+    ports:
+      - 10042:10042
     depends_on:
       - db
       - redis


### PR DESCRIPTION
This is needed to access the application in DEV environment via http://localhost:10042/ or http://0.0.0.0:10042/.