### PR TITLE
Fix a possible bug in `/src/utils/rating.py`

### DIFF
--- a/src/utils/rating.py
+++ b/src/utils/rating.py
@@ -15,7 +15,7 @@ def get_last_activity_weight(last_activity, base=None):
         return 0
     base = base or datetime.now(utc)
     n_activities = (base - last_activity) / timedelta(days=180)
-    return 0.9 ** min(n_activities, 0)
+    return 0.9 ** max(n_activities, 0)
 
 
 def get_weighted_rating(wratings, target, threshold=0.95, cache=None) -> float:


### PR DESCRIPTION
In `/src/utils/rating.py`, I noticed the function `get_last_activity_weight()` looks like this:

```python
def get_last_activity_weight(last_activity, base=None):
    if not last_activity:
        return 0
    base = base or datetime.now(utc)
    n_activities = (base - last_activity) / timedelta(days=180)
    return 0.9 ** min(n_activities, 0)  
```

This function is only used in the context of `/src/ranking/management/commands/set_country_fields.py`:

```python
weight *= get_last_activity_weight(account_stat['last_rating_activity'],
                                   base=last_rated_contest.end_time)
```

I believe `last_rated_contest.end_time` is always greater than `account_stat['last_rating_activity']`, so the function always returns `1`.

I fixed to:

```python
    return 0.9 ** max(n_activities, 0) 
```